### PR TITLE
fix(api): Changed way persons collection is populated

### DIFF
--- a/api/db/db.go
+++ b/api/db/db.go
@@ -62,6 +62,12 @@ func PopulatePersonsCollection(client *mongo.Client, dbName string, personsToIns
 		return "Failed to access Persons collection"
 	}
 
+	// Delete existing documents in the collection
+	_, err := collection.DeleteMany(context.TODO(), map[string]interface{}{})
+	if err != nil {
+		return "Failed to delete existing documents: " + err.Error()
+	}
+
 	// Insert persons into the collection
 	personsInterface := []interface{}{}
 	for _, person := range personsToInsert.Persons {
@@ -276,14 +282,10 @@ func InitDB(mongoClient *mongo.Client) error {
 		return fmt.Errorf("failed to check existing persons: %v", err)
 	}
 
-	if len(existingPersons.Persons) == 0 {
-		fmt.Println("Populating Persons collection...")
-		result := PopulatePersonsCollection(mongoClient, "dodle", persons)
-		if result != "" {
-			return fmt.Errorf("failed to populate persons collection: %s", result)
-		}
-	} else {
-		fmt.Println("Persons collection already contains data, skipping population")
+	fmt.Println("Populating Persons collection...")
+	result := PopulatePersonsCollection(mongoClient, "dodle", persons)
+	if result != "" {
+		return fmt.Errorf("failed to populate persons collection: %s", result)
 	}
 
 	return nil


### PR DESCRIPTION
This pull request focuses on changes to the database initialization and population logic in the `api/db/db.go` file. The updates ensure that the `Persons` collection is always cleared and repopulated during initialization, simplifying the process and removing conditional checks for existing data.

### Database initialization and population changes:

* **Clear `Persons` collection before population**: Added logic in `PopulatePersonsCollection` to delete all existing documents in the `Persons` collection before inserting new data. This ensures a clean slate for every population operation. (`[api/db/db.goR65-R70](diffhunk://#diff-0133ff04366cb6dfb954c552b68c21bf563ded008e5a5b2a4d513e7426cd61f0R65-R70)`)
* **Removed conditional check for existing data**: Simplified the `InitDB` function by removing the check for existing data in the `Persons` collection. The population process now always executes, regardless of the collection's prior state. (`[api/db/db.goL279-L287](diffhunk://#diff-0133ff04366cb6dfb954c552b68c21bf563ded008e5a5b2a4d513e7426cd61f0L279-L287)`)