### PR TITLE
fix(front): Switched colors between submit and hint

### DIFF
--- a/front/src/components/GuessGame.vue
+++ b/front/src/components/GuessGame.vue
@@ -456,22 +456,22 @@ const getFieldClass = (resultField: string, guessedField: string) => {
 }
 
 .submit-button {
-    background-color: #3a3a3c;
+    background-color: #28a745;
     color: white;
 }
 
 .submit-button:hover:not(:disabled) {
-    background-color: #2c2c2e;
+    background-color: #1e7e34;
 }
 
 .hint-button {
-    background-color: #28a745;
+    background-color: #3a3a3c;
     border: none;
     color: white;
 }
 
 .hint-button:hover:not(:disabled) {
-    background-color: #1e7e34;
+    background-color: #2c2c2e;
 }
 
 .submit-button:disabled,


### PR DESCRIPTION
This pull request updates the styling of buttons in the `GuessGame.vue` component to improve visual consistency and align with the intended design.

Styling changes:

* Updated the `.submit-button` to use a green background (`#28a745`) instead of gray, and adjusted its hover state to a darker green (`#1e7e34`).
* Changed the `.hint-button` to use a gray background (`#3a3a3c`) instead of green, and updated its hover state to a darker gray (`#2c2c2e`).