### PR TITLE
fix(front): Changed color of wrong parameters for red

### DIFF
--- a/front/src/components/GuessGame.vue
+++ b/front/src/components/GuessGame.vue
@@ -585,7 +585,7 @@ const getFieldClass = (resultField: string, guessedField: string) => {
 }
 
 .cell.incorrect {
-    background-color: #3a3a3c;
+    background-color: #aa423e;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
This pull request updates the styling for the `GuessGame` component to improve visual feedback for incorrect guesses.

Styling changes:

* [`front/src/components/GuessGame.vue`](diffhunk://#diff-3f105379e3e8f9f6603b2cab7740d30d3c03b2720d15d0b221438644515dd4dfL588-R588): Updated the background color for `.cell.incorrect` from `#3a3a3c` to `#aa423e` to make incorrect guesses more visually distinct.